### PR TITLE
RFC: Add a new timing.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -132,8 +132,8 @@
                     <th v-if="!display.comments" class="column-ipv6">IPv6<a class="help" href="#help-ipv6">?</a></th>
                     <th v-if="!display.comments" class="column-country">Country<a class="help" href="#help-country">?</a></th>
                     <th v-if="!display.comments" class="column-network">Network</th>
+                    <th v-if="!display.comments" class="column-responsetime">Search response time</th>
                     <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
-                    <th v-if="!display.comments" class="column-responsetime">Index response time</th>
                     <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
                     <th v-if="!display.comments" class="column-responsetime">Google response time</th>
                     <th v-if="display.comments" class="column-comments">Comments</th>
@@ -171,8 +171,8 @@
                     <td v-if="!display.comments" class="column-ipv6"><ipv6-component :value="detail.network"></ipv6-component></td>
                     <td v-if="!display.comments" class="column-country"><network-country-component :value="detail.network" :asns="$root.asns"></network-country-component></td>
                     <td v-if="!display.comments" class="column-network"><network-name-component :value="detail.network" :asns="$root.asns"></network-name-component></td>
+                    <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
-                    <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.index" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_go" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="display.comments" class="column-comments">

--- a/html/index.html
+++ b/html/index.html
@@ -118,7 +118,7 @@
         </p>
         <div v-if="selected_tab === 'online_https'">
           <h2>{{instances_filtered.length}} online instances</h2>
-          <p><small>See the <a href="#" v-on:click="selected_tab='about'">About</a> section to know how to edit this list or look for the meta searx instances</small></p>
+          <p>See the <a href="#" v-on:click="selected_tab='about'">About</a> section to know how to edit this list or look for the meta searx instances</p>
           <div class="table-responsive">
             <table class="table table-bordered table-striped table-hover">
                 <thead>
@@ -133,29 +133,30 @@
                     <th v-if="!display.comments" class="column-country">Country<a class="help" href="#help-country">?</a></th>
                     <th v-if="!display.comments" class="column-network">Network</th>
                     <th v-if="!display.comments" class="column-responsetime">Search response time</th>
-                    <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
-                    <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
                     <th v-if="!display.comments" class="column-responsetime">Google response time</th>
+                    <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
+                    <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
                     <th v-if="display.comments" class="column-comments">Comments</th>
                     <th v-if="display.comments" class="column-alternativeurls">Alternative URLs</th>
                   </tr>
                   <tr>
                       <th class="column-url"></th>
                       <th class="column-version"><input v-model="filters.version"/></th>
-                      <th v-if="!display.comments" class="column-tls"><input v-model="filters.tls_grade"/></th>
-                      <th v-if="!display.comments" class="column-csp"><input v-model="filters.csp_grade"/></th>
-                      <th v-if="!display.comments" class="column-html"><input v-model="filters.html_grade"/></th>
-                      <th v-if="!display.comments" class="column-certificate"></th>
-                      <th v-if="!display.comments" class="column-ipv6"><input v-model="filters.ipv6" type="checkbox" /></th>
-                      <th v-if="!display.comments" class="column-country"><input v-model="filters.network_country"/></th>
-                      <th v-if="!display.comments" class="column-network"><input v-model="filters.network_name" style="width: 90%" />
+                      <th v-if="!display.comments" class="column-tls"><div class="column-filter"><input v-model="filters.tls_grade"/></div></th>
+                      <th v-if="!display.comments" class="column-csp"><div class="column-filter"><input v-model="filters.csp_grade"/></div></th>
+                      <th v-if="!display.comments" class="column-html"><div class="column-filter"><input v-model="filters.html_grade"/></div></th>
+                      <th v-if="!display.comments" class="column-certificate"><div class="column-filter"></div></th>
+                      <th v-if="!display.comments" class="column-ipv6"><div class="column-filter"><input v-model="filters.ipv6" type="checkbox" /></div></th>
+                      <th v-if="!display.comments" class="column-country"><div class="column-filter"><input v-model="filters.network_country"/></div></th>
+                      <th v-if="!display.comments" class="column-network"><div class="column-filter">
+                        <input v-model="filters.network_name" style="width: 90%" />
                         <span><input v-model="filters.asn_privacy" type="checkbox" style="margin: 0 0.25em;vertical-align: middle; width:auto;" /></span>
                         <span class="info-tooltip">Hide networks with privacy issue</span>
-                      </th>
+                      </div></th>
+                      <th v-if="!display.comments" class="column-responsetime"><div class="column-filter"><input v-model="filters.standard_search" type="checkbox" /></div></th>
+                      <th v-if="!display.comments" class="column-responsetime"><div class="column-filter"><input v-model="filters.google" type="checkbox" /></div></th>
                       <th v-if="!display.comments" class="column-responsetime"></th>
                       <th v-if="!display.comments" class="column-responsetime"></th>
-                      <th v-if="!display.comments" class="column-responsetime"></th>
-                      <th v-if="!display.comments" class="column-responsetime"><input v-model="filters.google" type="checkbox" /></th>
                       <th v-if="display.comments" class="column-comments"></th>
                       <th v-if="display.comments" class="column-alternativeurls"></th>
                   </tr>
@@ -172,9 +173,9 @@
                     <td v-if="!display.comments" class="column-country"><network-country-component :value="detail.network" :asns="$root.asns"></network-country-component></td>
                     <td v-if="!display.comments" class="column-network"><network-name-component :value="detail.network" :asns="$root.asns"></network-name-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search" :time_select="$root.display.time_select"></time-component></td>
-                    <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
-                    <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_go" :time_select="$root.display.time_select"></time-component></td>
+                    <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
+                    <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
                     <td v-if="display.comments" class="column-comments">
                       <p v-for="comment in detail.comments">{{comment}}</p>
                     </td>
@@ -189,7 +190,7 @@
             </div>
 
             <h4 id="help-tls-grade">TLS grade</h4>
-            <p>Grade from <a href="https://cryptcheck.fr/">cryptcheck.fr</a> (<a href="https://github.com/aeris/cryptcheck">source code</a>).</p>
+            <p>Grade from <a href="https://cryptcheck.fr/">cryptcheck.fr</a> (source code: <a href="https://github.com/aeris/cryptcheck">aeris/cryptcheck</a> and <a href="https://github.com/dalf/cryptcheck-backend">dalf/cryptcheck-backend</a>).</p>
 
             <h4 id="help-csp-grade">CSP grade</h4>
             <p>Grade from <a href="https://observatory.mozilla.org/faq.html">Observatory by mozilla</a>.</p>
@@ -210,6 +211,14 @@
 
             <h4 id="help-country">Country</h4>
             <p>From whois information of the IPs</p>
+
+            <h4 id="help-responsetime">Response time colums</h4>
+            <ul>
+              <li>Search response time - response time with a search without configuration</li>
+              <li>Google response time - respones time of the Google engine</li>
+              <li>Wikipedia response time - response time of the Wikipedia engine</li>
+              <li>Initial response time - response time of the front time without prior existing connection</li>
+            </ul>
 
             <h4 id="help-timing">Displayed time</h4>
             <ul>
@@ -234,9 +243,9 @@
                       <th class="column-version">Version</th>
                       <th v-if="!display.comments" class="column-html">HTML<a class="help" href="#help-http-grade">?</a></th>
                       <th v-if="!display.comments" class="column-responsetime">Search response time</th>
-                      <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
-                      <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
                       <th v-if="!display.comments" class="column-responsetime">Google response time</th>
+                      <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
+                      <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
                       <th v-if="display.comments" class="column-comments">Comments</th>
                       <th v-if="display.comments" class="column-alternativeurls">Alternative URLs</th>
                     </tr>
@@ -247,9 +256,9 @@
                       <td class="column-version">{{detail.version}}</td>
                       <td v-if="!display.comments" class="column-html"><html-component :value="detail.html" :hashes="$root.hashes" :url="detail.url"></html-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search" :time_select="$root.display.time_select"></time-component></td>
-                      <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
-                      <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_go" :time_select="$root.display.time_select"></time-component></td>
+                      <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
+                      <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="display.comments" class="column-comments">
                         <p v-for="comment in detail.comments">{{comment}}</p>
                       </td>

--- a/html/index.html
+++ b/html/index.html
@@ -233,8 +233,8 @@
                       <th class="column-url">URL</th>
                       <th class="column-version">Version</th>
                       <th v-if="!display.comments" class="column-html">HTML<a class="help" href="#help-http-grade">?</a></th>
+                      <th v-if="!display.comments" class="column-responsetime">Search response time</th>
                       <th v-if="!display.comments" class="column-responsetime">Initial response time</th>
-                      <th v-if="!display.comments" class="column-responsetime">Index response time</th>
                       <th v-if="!display.comments" class="column-responsetime">Wikipedia response time</th>
                       <th v-if="!display.comments" class="column-responsetime">Google response time</th>
                       <th v-if="display.comments" class="column-comments">Comments</th>
@@ -246,8 +246,8 @@
                       <td class="column-url"><url-component :url="detail.url" :alternativeurls="detail.alternativeUrls" :comments ="detail.comments"></url-component></td>
                       <td class="column-version">{{detail.version}}</td>
                       <td v-if="!display.comments" class="column-html"><html-component :value="detail.html" :hashes="$root.hashes" :url="detail.url"></html-component></td>
+                      <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.initial" :time_select="$root.display.time_select"></time-component></td>
-                      <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.index" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_wp" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="!display.comments" class="column-responsetime"><time-component :value="detail.timing.search_go" :time_select="$root.display.time_select"></time-component></td>
                       <td v-if="display.comments" class="column-comments">

--- a/html/main.css
+++ b/html/main.css
@@ -30,6 +30,11 @@
   z-index: 1000000;
 }
 
+/* hack */
+.column-filter .info-tooltip {
+  margin: 2em 0 0 2em;
+}
+
 .info-tooltip p {
   margin: 0.125rem;
 }
@@ -58,7 +63,6 @@ a:hover + .info-tooltip,
 span:hover + .info-tooltip,
 .info-tooltip:hover {
   display: block;
-  /* opacity: 1; */
 }
 
 sup {
@@ -109,13 +113,18 @@ tbody .column-url, tbody .column-certificate {
 
 tbody .column-url:hover, tbody .column-certificate:hover {
   position: absolute;
-  background: white;
+  background: inherit;
   border: none;
   width: auto;
   overflow: visible;
   text-overflow: inherit;
   word-break: keep-all;
   white-space: nowrap;
+}
+
+main thead th {
+  padding: 2px;
+  vertical-align: middle !important;
 }
 
 .column-status {
@@ -151,6 +160,13 @@ tbody .column-url:hover, tbody .column-certificate:hover {
   width: 9rem;
   text-align: right;
 }
+
+.column-filter {
+  display: flex;
+  flex-direction: row;
+  align-content: center;
+}
+
 
 div.table-responsive table th.column-responsetime {
   white-space: normal;

--- a/html/main.js
+++ b/html/main.js
@@ -24,7 +24,7 @@ const COMMON_ERROR_MESSAGE = {
 };
 
 const SORT_CRITERIAS = ['http.status_code', 'error', 'timing.search.error', 'version', 'tls.grade',
-   'http.grade', 'html.grade', 'timing.search.all', 'url'];
+    'http.grade', 'html.grade', 'timing.search.all', 'url'];
 
 const HTML_GRADE_MAPPING = {
     'V': 3,
@@ -236,8 +236,8 @@ function hslResponseTime(value, successRate) {
     if (value === 'N/A') {
         value = 2;
     }
-    const responseTimeInPercentage = translateValue(value, 0.1, 2, 0, 100, true);
-    const successRateNormalized = translateValue(successRate || 100, 40, 90, 0, 100, false);
+    const responseTimeInPercentage = translateValue(value, 0.6, 2.5, 0, 100, true);
+    const successRateNormalized = translateValue(successRate || 100, 70, 100, 0, 100, false);
     const percentageShown = (responseTimeInPercentage / 100) * (successRateNormalized / 100) * 100;
     const h = translateValue(percentageShown, 0, 100, 0, 128, false);
     const s = translateValue(percentageShown, 0, 100, 39, 54, true);

--- a/html/main.js
+++ b/html/main.js
@@ -377,15 +377,17 @@ Vue.component('time-component', {
                 if (successRate !== undefined) {
                     tooltip_lines.push(h('p', `${successRate}% success`));
                 }
-                tooltip_add_timing(h, tooltip_lines, this.value.all, 'Total time');
-                tooltip_add_timing(h, tooltip_lines, this.value.server, 'Server time');
-                tooltip_add_timing(h, tooltip_lines, this.value.load, 'Load time');
             }
             if (this.value.error !== undefined ) {
                 tooltip_lines.push(h('p', `Error: ${this.value.error}`));
                 if (value === undefined) {
                     value = 'Error';
                 }
+            }
+            if (timing !== undefined) {
+                tooltip_add_timing(h, tooltip_lines, this.value.all, 'Total time');
+                tooltip_add_timing(h, tooltip_lines, this.value.server, 'Server time');
+                tooltip_add_timing(h, tooltip_lines, this.value.load, 'Load time');
             }
             if (this.value.error === 'No result' && this.value.success_percentage === 0) {
                 return undefined;
@@ -784,6 +786,7 @@ new Vue({
             asn_privacy: false,
             network_name: '',
             network_country: '',
+            standard_search: false,
             google: false,
         },
         display: {
@@ -837,6 +840,9 @@ new Vue({
             }
             if (this.filters.asn_privacy) {
                 result = result.filter((detail) => detail.network.asn_privacy >= 0);
+            }
+            if (this.filters.standard_search) {
+                result = result.filter((detail) => detail.timing.search.success_percentage > 0);
             }
             if (this.filters.google) {
                 result = result.filter((detail) => detail.timing.search_go.success_percentage > 0);

--- a/html/main.js
+++ b/html/main.js
@@ -23,8 +23,8 @@ const COMMON_ERROR_MESSAGE = {
     'Tor Error: ': 'Tor Error'
 };
 
-const SORT_CRITERIAS = ['http.status_code', 'error', 'version', 'tls.grade',
-    'http.grade', 'html.grade', 'timing.initial', 'url'];
+const SORT_CRITERIAS = ['http.status_code', 'error', 'timing.search.error', 'version', 'tls.grade',
+   'http.grade', 'html.grade', 'timing.search.all', 'url'];
 
 const HTML_GRADE_MAPPING = {
     'V': 3,
@@ -166,17 +166,38 @@ function compareVersion(a, b) {
     return 0;
 }
 
+
+function getTime(timing) {
+    if (timing.value !== undefined) {
+        return timing.value;
+    }
+    if (timing.median !== undefined) {
+        return timing.median;
+    }
+    return undefined;
+}
+
+function isError(timing) {
+    if (timing.success_percentage > 0) {
+        return false;
+    }
+    return (timing.error !== undefined);
+}
+
 const CompareFunctionCriterias = {
     'http.status_code': (a, b) => -compareTool(a, b, null, 'http', 'status_code'),
     'error': (a, b) => -compareTool(a, b, null, 'error'),
+    'error_wp': (a, b) => compareTool(a, b, null, 'timing', 'search_wp', 'error'),
     'network.asn_privacy': (a, b) => compareTool(a, b, null, 'network', 'asn_privacy'),
     'version': (a, b) => compareVersion(a.version, b.version),
     'tls.grade': (a, b) => compareTool(a, b, normalizeGrade, 'tls', 'grade'),
     'html.grade': (a, b) => compareTool(a, b, normalizeHtmlGrade, 'html', 'grade'),
     'http.grade': (a, b) => compareTool(a, b, normalizeGrade, 'http', 'grade'),
-    'timing.initial': (a, b) => -compareTool(a, b, null, 'timing', 'initial'),
-    'timing.search_wp.server.median': (a, b) => -compareTool(a, b, null, 'timing', 'search_wp', 'server', 'median'),
-    'timing.search_wp.all.median': (a, b) => -compareTool(a, b, null, 'timing', 'search_wp', 'all', 'median'),
+    'timing.initial.all': (a, b) => -compareTool(a, b, getTime, 'timing', 'initial', 'all'),
+    'timing.search.error': (a, b) => -compareTool(a, b, isError, 'timing', 'search'),
+    'timing.search.all': (a, b) => -compareTool(a, b, getTime, 'timing', 'search', 'all'),
+    'timing.search_wp.server': (a, b) => -compareTool(a, b, getTime, 'timing', 'search_wp', 'server'),
+    'timing.search_wp.all': (a, b) => -compareTool(a, b, getTime, 'timing', 'search_wp', 'all'),
     'url': (a, b) => -compareTool(a, b, null, 'url'),
 };
 
@@ -345,31 +366,34 @@ Vue.component('time-component', {
         if (this.value != null) {
             let successRate = 100;
             let value;
-            let tooltip_lines;
-            if (typeof (this.value) === 'object') {
-                const timing = this.value[this.time_select];
-                if (timing !== undefined) {
-                    value = this.value[this.time_select].median;
-                    if (value === undefined) {
-                        value = this.value[this.time_select].value;
-                    }
-                    successRate = this.value.success_percentage;
-                    tooltip_lines = [
-                        h('p', `${successRate}% success`),
-                    ];
-                    tooltip_add_timing(h, tooltip_lines, this.value.all, 'Total time');
-                    tooltip_add_timing(h, tooltip_lines, this.value.server, 'Server time');
-                    tooltip_add_timing(h, tooltip_lines, this.value.load, 'Load time');
-                    if (this.value.error !== undefined && this.value.error != 'Check failed') {
-                        tooltip_lines.push(h('p', `Error: ${this.value.error}`));
-                        if (value === undefined) {
-                            value = 'N/A';
-                        }
-                    }
+            let tooltip_lines = [];
+            const timing = this.value[this.time_select];
+            if (timing !== undefined) {
+                value = timing.median;
+                if (value === undefined) {
+                    value = timing.value;
                 }
-            } else if (this.time_select === 'all') {
-                value = this.value;
-                tooltip_lines = null;
+                successRate = this.value.success_percentage;
+                if (successRate !== undefined) {
+                    tooltip_lines.push(h('p', `${successRate}% success`));
+                }
+                tooltip_add_timing(h, tooltip_lines, this.value.all, 'Total time');
+                tooltip_add_timing(h, tooltip_lines, this.value.server, 'Server time');
+                tooltip_add_timing(h, tooltip_lines, this.value.load, 'Load time');
+            }
+            if (this.value.error !== undefined ) {
+                tooltip_lines.push(h('p', `Error: ${this.value.error}`));
+                if (value === undefined) {
+                    value = 'Error';
+                }
+            }
+            if (this.value.error === 'No result' && this.value.success_percentage === 0) {
+                return undefined;
+            }
+            if (value == 'Error') {
+                return createTooltip(h,
+                    h('span', value),
+                    tooltip_lines);
             }
             if (value !== undefined) {
                 return createTooltip(h,
@@ -846,15 +870,17 @@ new Vue({
                     setDefault(instance, 'tls', {});
                     setDefault(instance.tls, 'certificate', {});
                     setDefault(instance, 'timing', {});
-                    setDefault(instance.timing, 'index', {});
-                    setDefault(instance.timing.index, 'all', {});
+                    setDefault(instance.timing, 'initial', {});
+                    setDefault(instance.timing.initial, 'all', {});
+                    setDefault(instance.timing, 'search', {});
+                    setDefault(instance.timing.search, 'all', {});
                     setDefault(instance.timing, 'search_wp', {});
                     setDefault(instance.timing.search_wp, 'all', {});
                     setDefault(instance.timing, 'search_go', {});
                     setDefault(instance.timing.search_go, 'all', {});
                     setDefault(instance, 'html', {});
                     setDefault(instance.html, 'grade', '');
-                    setComputedTimes(instance.timing.index);
+                    setComputedTimes(instance.timing.search);
                     setComputedTimes(instance.timing.search_wp);
                     setComputedTimes(instance.timing.search_go);
 

--- a/searxstats/common/response_time.py
+++ b/searxstats/common/response_time.py
@@ -1,0 +1,103 @@
+import statistics
+
+
+def parse_server_timings(server_timing):
+    """
+    Parse the Server-Timing header
+    See
+    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
+    - https://w3c.github.io/server-timing/#the-server-timing-header-field
+    """
+    if server_timing == '':
+        return dict()
+
+    def parse_param(param):
+        """
+        Parse `dur=2067.665` or `desc="Total time"`
+
+        Convert `dur` param to second from millisecond
+        """
+        param = tuple(param.strip().split('='))
+        if param[0] == 'dur':
+            return param[0], float(param[1]) / 1000
+        else:
+            return param[0], param[1]
+
+    def parse_metric(str_metric):
+        """
+        Parse
+        - `total;dur=2067.665;desc="Total time"`
+        - or `total_0_ddg;dur=512.808` etc..
+        """
+        str_metric = str_metric.strip().split(';')
+        name = str_metric[0].strip()
+        param_tuples = map(parse_param, str_metric[1:])
+        params = dict(param_tuples)
+        return name, params
+
+    raw_timing_list = server_timing.split(',')
+    timing_list = list(map(parse_metric, raw_timing_list))
+    return dict(timing_list)
+
+
+def timings_stats(timings):
+    if len(timings) >= 2:
+        return {
+            'median': round(statistics.median(timings), 3),
+            'stdev': round(statistics.stdev(timings), 3),
+            'mean': round(statistics.mean(timings), 3)
+        }
+    elif len(timings) == 1:
+        return {
+            'value': round(timings[0], 3)
+        }
+    else:
+        return None
+
+
+def get_load_time(one_server_timings):
+    load_timings = dict(filter(lambda i: i[0].startswith('load_'), one_server_timings.items()))
+    load_timings = list(map(lambda v: v.get('dur', None), load_timings.values()))
+    if len(load_timings) > 0:
+        return max(load_timings)
+    else:
+        return None
+
+
+def set_timings_stats(result, key, timings):
+    stats = timings_stats(timings)
+    if stats is not None:
+        result[key] = stats
+
+
+class ResponseTimeStats:
+
+    def __init__(self):
+        self.all_timings = []
+        self.server_timings = []
+        self.load_timings = []
+        self.count = 0
+
+    def add_response(self, response):
+        self.count += 1
+        if response is not None:
+            self.all_timings.append(response.elapsed.total_seconds())
+            server_timing_values = parse_server_timings(response.headers.get('server-timing', ''))
+            server_time = server_timing_values.get('total', {}).get('dur', None)
+            if server_time is not None:
+                self.server_timings.append(server_time)
+            load_time = get_load_time(server_timing_values)
+            if load_time is not None:
+                self.load_timings.append(load_time)
+
+    def get(self):
+        if self.count == 0:
+            result = {}
+        else:
+            result = {
+                'success_percentage': round(len(self.all_timings) * 100 / self.count, 0)
+            }
+            set_timings_stats(result, 'all', self.all_timings)
+            set_timings_stats(result, 'server', self.server_timings)
+            set_timings_stats(result, 'load', self.load_timings)
+        return result

--- a/searxstats/config.py
+++ b/searxstats/config.py
@@ -13,7 +13,7 @@ BROWSER_LOAD_TIMEOUT = 20
 
 # Default headers for all HTTP requests
 DEFAULT_HEADERS = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:73.0) Gecko/20100101 Firefox/73.0',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
     'Accept-Language': 'en-US,en;q=0.5',
     'DNT': '1',

--- a/searxstats/config.py
+++ b/searxstats/config.py
@@ -8,9 +8,6 @@ TOR_SOCKS_PROXY_PORT = 9050
 # Local cryptcheck-backend
 CRYPTCHECK_BACKEND = 'http://127.0.0.1:7000'
 
-# Request count to measure response time
-REQUEST_COUNT = 6
-
 # Fetcher.external_ressource: load page timeout, in seconds
 BROWSER_LOAD_TIMEOUT = 20
 

--- a/searxstats/fetcher/__init__.py
+++ b/searxstats/fetcher/__init__.py
@@ -45,7 +45,7 @@ FETCHERS = [
             'other'),
     Fetcher(timing,
             'timing',
-            'Test the response time 🔎🐘🔍🏁❌',
+            'Test the response time 🐘🔎🔍🏁❌',
             'timing'),
 ]
 

--- a/searxstats/fetcher/__init__.py
+++ b/searxstats/fetcher/__init__.py
@@ -45,7 +45,7 @@ FETCHERS = [
             'other'),
     Fetcher(timing,
             'timing',
-            'Test the response time 🐘🔎🔍🏁❌',
+            'Test the response time 🔎🐘🔍🏁❌',
             'timing'),
 ]
 

--- a/searxstats/fetcher/__init__.py
+++ b/searxstats/fetcher/__init__.py
@@ -45,7 +45,7 @@ FETCHERS = [
             'other'),
     Fetcher(timing,
             'timing',
-            'Test the response time 🏠🔎🔍🏁❌',
+            'Test the response time 🔎🐘🔍🏁❌',
             'timing'),
 ]
 

--- a/searxstats/fetcher/basic.py
+++ b/searxstats/fetcher/basic.py
@@ -7,6 +7,7 @@ from searxstats.common.utils import dict_merge
 from searxstats.common.http import new_client, get, get_host, get_network_type, NetworkType
 from searxstats.common.ssl_info import get_ssl_info
 from searxstats.common.memoize import MemoizeToDisk
+from searxstats.common.response_time import ResponseTimeStats
 from searxstats.config import DEFAULT_HEADERS
 
 
@@ -45,7 +46,9 @@ async def fetch_one(instance_url: str, private: bool) -> dict:
             if response is not None:
                 detail['version'] = await get_searx_version(response)
                 detail['timing'] = {}
-                detail['timing']['initial'] = response.elapsed.total_seconds()
+                response_time_stats = ResponseTimeStats()
+                response_time_stats.add_response(response)
+                detail['timing']['initial'] = response_time_stats.get()
                 response_url = str(response.url)
                 # add trailing slash
                 if not response_url.endswith('/'):
@@ -78,7 +81,7 @@ async def fetch_one_display(url: str, private: bool) -> dict:
     error = detail['http']['error'] or ''
     http_status_code = detail['http'].get('status_code', '') or ''
     searx_version = detail.get('version', '') or ''
-    timing = detail.get('timing', {}).get('initial') or None
+    timing = detail.get('timing', {}).get('initial', {}).get('all', {}).get('value', None)
     cert_orgname = detail.get('tls', {}).get('certificate', {}).get('issuer', {}).get('organizationName', '')
     if error != '':
         icon = '❌'

--- a/searxstats/fetcher/timing.py
+++ b/searxstats/fetcher/timing.py
@@ -2,38 +2,38 @@ import sys
 import traceback
 import asyncio
 import random
-import statistics
 import httpx
 
 from lxml import etree
 from searxstats.common.utils import exception_to_str
 from searxstats.common.html import extract_text, html_fromstring
-from searxstats.common.http import new_client, get, get_network_type
+from searxstats.common.http import new_client, get, get_network_type, NetworkType
 from searxstats.common.memoize import MemoizeToDisk
-from searxstats.config import REQUEST_COUNT, DEFAULT_COOKIES, DEFAULT_HEADERS
+from searxstats.common.response_time import ResponseTimeStats
+from searxstats.config import DEFAULT_COOKIES, DEFAULT_HEADERS
 from searxstats.model import create_fetch
 
 
 RESULTS_XPATH = etree.XPath(
     "//div[@id='main_results']/div[contains(@class,'result-default')]")
 ENGINE_XPATH = etree.XPath("//span[contains(@class, 'label')]")
-
-
-class RequestErrorException(Exception):
-    pass
+# There is no result, error on the main section
+ALERT_DANGER_MAIN_XPATH = etree.XPath("//div[contains(@class, 'alert-danger')]/p[2]")
+# There are results, error on the side (above infoboxes)
+ALERT_DANGER_SIDE_XPATH = etree.XPath("//div[contains(@class, 'alert-danger')]/text()")
 
 
 async def check_html_result_page(engine_name, response):
     document = await html_fromstring(response.text)
     result_element_list = RESULTS_XPATH(document)
     if len(result_element_list) == 0:
-        return False
+        return False, 'No result'
     for result_element in result_element_list:
         for engine_element in ENGINE_XPATH(result_element):
             if extract_text(engine_element).find(engine_name) >= 0:
                 continue
-            return False
-    return True
+            return False, 'A result is not from the engine'
+    return True, None
 
 
 async def check_google_result(response):
@@ -44,80 +44,26 @@ async def check_wikipedia_result(response):
     return await check_html_result_page('wikipedia', response)
 
 
-def parse_server_timings(server_timing):
-    """
-    Parse the Server-Timing header
-    See
-    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
-    - https://w3c.github.io/server-timing/#the-server-timing-header-field
-    """
-    if server_timing == '':
-        return dict()
-
-    def parse_param(param):
-        """
-        Parse `dur=2067.665` or `desc="Total time"`
-
-        Convert `dur` param to second from millisecond
-        """
-        param = tuple(param.strip().split('='))
-        if param[0] == 'dur':
-            return param[0], float(param[1]) / 1000
-        else:
-            return param[0], param[1]
-
-    def parse_metric(str_metric):
-        """
-        Parse
-        - `total;dur=2067.665;desc="Total time"`
-        - or `total_0_ddg;dur=512.808` etc..
-        """
-        str_metric = str_metric.strip().split(';')
-        name = str_metric[0].strip()
-        param_tuples = map(parse_param, str_metric[1:])
-        params = dict(param_tuples)
-        return name, params
-
-    raw_timing_list = server_timing.split(',')
-    timing_list = list(map(parse_metric, raw_timing_list))
-    return dict(timing_list)
-
-
-def timings_stats(timings):
-    if len(timings) >= 2:
-        return {
-            'median': statistics.median(timings),
-            'stdev': statistics.stdev(timings),
-            'mean': statistics.mean(timings)
-        }
-    elif len(timings) == 1:
-        return {
-            'value': timings
-        }
-    else:
-        return None
-
-
-def set_timings_stats(result, key, timings):
-    stats = timings_stats(timings)
-    if stats is not None:
-        result[key] = stats
-
-
-def get_load_time(one_server_timings):
-    load_key = list(filter(lambda k: k.startswith('load_0_'), one_server_timings.keys()))
-    if len(load_key) > 0:
-        return one_server_timings[load_key[0]].get('dur', None)
-    else:
-        return None
+async def check_search_result(response):
+    document = await html_fromstring(response.text)
+    result_element_list = RESULTS_XPATH(document)
+    alert_danger_list = ALERT_DANGER_MAIN_XPATH(document)
+    if len(alert_danger_list) > 0:
+        return True, extract_text(alert_danger_list)
+    alert_danger_list = ALERT_DANGER_SIDE_XPATH(document)
+    if len(alert_danger_list) > 0:
+        return True, extract_text(alert_danger_list)
+    if len(result_element_list) == 0:
+        return False, 'No result'
+    if len(result_element_list) == 1:
+        return False, 'Only one result'
+    if len(result_element_list) == 2:
+        return False, 'Only two results'
+    return True, None
 
 
 # pylint: disable=too-many-arguments, too-many-locals
 async def request_stat(session, url, count, between_a, and_b, check_results, **kwargs):
-    all_timings = []
-    server_timings = []
-    load_timings = []
-
     headers = kwargs.get('headers', dict())
     headers.update(DEFAULT_HEADERS)
     kwargs['headers'] = headers
@@ -126,52 +72,48 @@ async def request_stat(session, url, count, between_a, and_b, check_results, **k
     cookies.update(DEFAULT_COOKIES)
     kwargs['cookies'] = cookies
 
-    error = None
+    error_msg = None
     error_count = 0
-    loop_count = 0
 
-    for i in range(0, count):
-        loop_count += 1
+    response_time_stats = ResponseTimeStats()
+
+    for i in range(1, count+1):
         await asyncio.sleep(random.randint(a=between_a, b=and_b))
-        response, error = await get(session, url, **kwargs)
-        if i == 0 and error is not None and error.startswith('HTTP status code 5'):
+        response, error_msg = await get(session, url, **kwargs)
+        if i == 0 and error_msg is not None and error_msg.startswith('HTTP status code 5'):
             # cookie settings may cause a server error: disable them and try again
             # check only on the first request
             del kwargs['cookies']
-            response, error = await get(session, url, **kwargs)
-        if error is not None:
+            response, error_msg = await get(session, url, **kwargs)
+        if error_msg is not None:
+            response_time_stats.add_response(None)
             break
         await response.aread()
-        if (not check_results) or (check_results and (await check_results(response))):
-            all_timings.append(response.elapsed.total_seconds())
-            server_timing_values = parse_server_timings(response.headers.get('server-timing', ''))
-            server_time = server_timing_values.get('total', {}).get('dur', None)
-            if server_time is not None:
-                server_timings.append(server_time)
-            load_time = get_load_time(server_timing_values)
-            if load_time is not None:
-                load_timings.append(load_time)
+        # check response
+        if not check_results:
+            valid_response = True
         else:
-            error = 'Check failed'
+            valid_response, error_msg = await check_results(response)
+        #
+        if valid_response:
+            response_time_stats.add_response(response)
+        else:
+            response_time_stats.add_response(None)
             error_count += 1
             if error_count > 3:
                 break
-    result = {
-        'success_percentage': round(len(all_timings) * 100 / loop_count, 0)
-    }
-    set_timings_stats(result, 'all', all_timings)
-    set_timings_stats(result, 'server', server_timings)
-    set_timings_stats(result, 'load', load_timings)
-    if error is not None:
-        result['error'] = error
+    result = {}
+    result.update(response_time_stats.get())
+    if error_msg is not None:
+        result['error'] = error_msg
     return result
 
 
-async def request_stat_with_exception(obj, key, *args, **kwargs):
+async def request_stat_with_log(instance, obj, key, *args, **kwargs):
     result = await request_stat(*args, **kwargs)
     obj[key] = result
     if 'error' in result:
-        raise RequestErrorException(result['error'])
+        print(f'❌ {str(instance)}: {key}: {result["error"]}')
 
 
 @MemoizeToDisk()
@@ -180,26 +122,26 @@ async def fetch_one(instance: str) -> dict:
     try:
         user_pool_limits = httpx.PoolLimits(soft_limit=10, hard_limit=300)
         network_type = get_network_type(instance)
-        async with new_client(pool_limits=user_pool_limits, network_type=network_type) as session:
+        timeout = 5 if network_type == NetworkType.NORMAL else 20
+        async with new_client(pool_limits=user_pool_limits, timeout=timeout, network_type=network_type) as session:
             # check index with a new connection each time
-            print('🏠 ' + instance)
-            await request_stat_with_exception(timings, 'index',
-                                              session, instance,
-                                              REQUEST_COUNT, 20, 40, None)
-            # check wikipedia engine with a new connection each time
             print('🔎 ' + instance)
-            await request_stat_with_exception(timings, 'search_wp',
-                                              session, instance,
-                                              REQUEST_COUNT, 30, 60, check_wikipedia_result,
-                                              params={'q': '!wp time'})
+            await request_stat_with_log(instance, timings, 'search',
+                                        session, instance,
+                                        3, 30, 60, check_search_result,
+                                        params={'q': 'time'})
+            # check wikipedia engine with a new connection each time
+            print('🐘 ' + instance)
+            await request_stat_with_log(instance, timings, 'search_wp',
+                                        session, instance,
+                                        3, 30, 60, check_wikipedia_result,
+                                        params={'q': '!wp time'})
             # check google engine with a new connection each time
             print('🔍 ' + instance)
-            await request_stat_with_exception(timings, 'search_go',
-                                              session, instance,
-                                              2, 60, 80, check_google_result,
-                                              params={'q': '!google time'})
-    except RequestErrorException as ex:
-        print('❌ {0}: {1}'.format(str(instance), str(ex)))
+            await request_stat_with_log(instance, timings, 'search_go',
+                                        session, instance,
+                                        2, 60, 80, check_google_result,
+                                        params={'q': '!google time'})
     except Exception as ex:
         print('❌❌ {0}: unexpected {1} {2}'.format(str(instance), type(ex), str(ex)))
         timings['error'] = exception_to_str(ex)

--- a/searxstats/fetcher/timing.py
+++ b/searxstats/fetcher/timing.py
@@ -134,12 +134,12 @@ async def fetch_one(instance: str) -> dict:
             # intended side effect: add one HTTP connection to the pool
             cookies = await get_cookie_settings(client, instance)
 
-            # check the google engine
-            print('🔍 ' + instance)
-            await request_stat_with_log(instance, timings, 'search_go',
+            # check the default engines
+            print('🔎 ' + instance)
+            await request_stat_with_log(instance, timings, 'search',
                                         client, instance,
-                                        2, 60, 160, check_google_result,
-                                        params={'q': '!google time'},
+                                        3, 120, 160, check_search_result,
+                                        params={'q': 'time'},
                                         cookies=cookies, headers=DEFAULT_HEADERS)
 
             # check the wikipedia engine
@@ -150,13 +150,13 @@ async def fetch_one(instance: str) -> dict:
                                         params={'q': '!wp time'},
                                         cookies=cookies, headers=DEFAULT_HEADERS)
 
-            # check the default engines
+            # check the google engine
             # may include google results too, so wikipedia engine check before
-            print('🔎 ' + instance)
-            await request_stat_with_log(instance, timings, 'search',
+            print('🔍 ' + instance)
+            await request_stat_with_log(instance, timings, 'search_go',
                                         client, instance,
-                                        3, 120, 160, check_search_result,
-                                        params={'q': 'time'},
+                                        2, 60, 160, check_google_result,
+                                        params={'q': '!google time'},
                                         cookies=cookies, headers=DEFAULT_HEADERS)
     except Exception as ex:
         print('❌❌ {0}: unexpected {1} {2}'.format(str(instance), type(ex), str(ex)))


### PR DESCRIPTION
Output: https://searx.space/experimental/

The columns:
* Search response time: response time to search for "time" (default engines), same as stats.searx.xyz, but there are 3 requests.
* Initial response time: time for the first connection (The server time is now recorded).

The values:
* ```Error``` means there is an ... error
* nothing means there is no result
* the numerical value is the median.

Sort order: 
* timing.search.error
* version
* tls.grade
* http.grade
* html.grade
* timing.search.all
* all

I don't know if it is better, but there are way too much information IMO.