### PR TITLE
Remove discontinued & custom engines in general category

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -850,7 +850,9 @@ new Vue({
         },
         selected_engines: function() {
             let result = Object.keys(this.engines).filter((engine) => (this.engines[engine].categories.includes(this.selected_category)));
-            result.sort();
+            const discontinued = ['asksteem', 'faroo', 'findx', 'ixquick', 'swisscows'];
+            const custom = ['Duden', 'everdot yacy network', 'global yacy network', 'immortalpoetry', 'linuxreviews yacy network', 'linuxreviews.org', 'namepros', 'pcgamingwiki', 'wikichip', 'wikispooks'];
+            result = result.filter(n => !discontinued.includes(n)).filter(n => !custom.includes(n)).sort();
             return result;
         },
     },


### PR DESCRIPTION
This is a quick proposal to hide stats for discontinued & custom engines.

 - *Discontinued* means they have been removed from searx core because the engines are no longer supported ;

 - *Custom* means they are obsolete naming of engines or are not supported in core as they were only implemented by a few instances with proprietary code.

I think engines stats needs to be cleaned up, and this would be the best way to do it.

The goal is to progressively check which engines are really supported by core and to make more human-readable searx engine statistics.

Fixes: https://github.com/dalf/searx-stats2/issues/39