### PR TITLE
Fix default port for searx-stats2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ docker-run: # Run the container
 	    --all
 
 webserver:
-	cd $(ROOT_DIR)/html; python -m http.server 8888
+	cd $(ROOT_DIR)/html; python -m http.server 8889


### PR DESCRIPTION
Default port should be 8889 as 8888 is used by [searx](https://github.com/asciimoo/searx/blob/master/docs/admin/installation-nginx.rst) core itself.